### PR TITLE
Proactive CID rotation

### DIFF
--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -1,17 +1,20 @@
 use rand::RngCore;
+use std::time::Duration;
 
 use crate::shared::ConnectionId;
 use crate::MAX_CID_SIZE;
 
 /// Generates connection IDs for incoming connections
 pub trait ConnectionIdGenerator: Send {
-    /// Generates a new CID
+    /// Generates a new CID with finite lifetime
     ///
     /// Connection IDs MUST NOT contain any information that can be used by
     /// an external observer (that is, one that does not cooperate with the
     /// issuer) to correlate them with other connection IDs for the same
     /// connection.
-    fn generate_cid(&mut self) -> ConnectionId;
+    ///
+    /// Connection IDs will be proactively retired if lifetime is given a value.
+    fn generate_cid(&mut self) -> (ConnectionId, Option<Duration>);
     /// Returns the length of a CID for cononections created by this generator
     fn cid_len(&self) -> usize;
 }
@@ -20,25 +23,41 @@ pub trait ConnectionIdGenerator: Send {
 #[derive(Debug, Clone, Copy)]
 pub struct RandomConnectionIdGenerator {
     cid_len: usize,
+    lifetime: Option<Duration>,
 }
 impl Default for RandomConnectionIdGenerator {
     fn default() -> Self {
-        Self { cid_len: 8 }
+        Self {
+            cid_len: 8,
+            lifetime: None,
+        }
     }
 }
 impl RandomConnectionIdGenerator {
     /// Initialize Random CID generator with a fixed CID length (which must be less or equal to MAX_CID_SIZE)
     pub fn new(cid_len: usize) -> Self {
         debug_assert!(cid_len <= MAX_CID_SIZE);
-        Self { cid_len }
+        Self {
+            cid_len,
+            ..RandomConnectionIdGenerator::default()
+        }
+    }
+
+    /// Set the lifetime of CIDs created by this generator
+    pub fn set_lifetime(&mut self, d: Duration) -> &mut Self {
+        self.lifetime = Some(d);
+        self
     }
 }
 impl ConnectionIdGenerator for RandomConnectionIdGenerator {
-    fn generate_cid(&mut self) -> ConnectionId {
+    fn generate_cid(&mut self) -> (ConnectionId, Option<Duration>) {
         let mut bytes_arr = [0; MAX_CID_SIZE];
         rand::thread_rng().fill_bytes(&mut bytes_arr[..self.cid_len]);
 
-        ConnectionId::new(&bytes_arr[..self.cid_len])
+        (
+            ConnectionId::new(&bytes_arr[..self.cid_len]),
+            self.lifetime,
+        )
     }
 
     /// Provide the length of dst_cid in short header packet

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -54,10 +54,7 @@ impl ConnectionIdGenerator for RandomConnectionIdGenerator {
         let mut bytes_arr = [0; MAX_CID_SIZE];
         rand::thread_rng().fill_bytes(&mut bytes_arr[..self.cid_len]);
 
-        (
-            ConnectionId::new(&bytes_arr[..self.cid_len]),
-            self.lifetime,
-        )
+        (ConnectionId::new(&bytes_arr[..self.cid_len]), self.lifetime)
     }
 
     /// Provide the length of dst_cid in short header packet

--- a/quinn-proto/src/cid_queue.rs
+++ b/quinn-proto/src/cid_queue.rs
@@ -15,7 +15,7 @@ pub struct CidQueue {
     ///
     /// The CID sequenced immediately prior to this is the active CID, which this data structure is
     /// not responsible for retiring.
-    offset: u64,
+    pub offset: u64,
 }
 
 impl CidQueue {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3062,8 +3062,8 @@ where
     #[cfg(test)]
     pub(crate) fn active_local_cid_seq(&self) -> (u64, u64) {
         (
-            self.cids_active_seq.iter().min().unwrap().clone(),
-            self.cids_active_seq.iter().max().unwrap().clone(),
+            *self.cids_active_seq.iter().min().unwrap(),
+            *self.cids_active_seq.iter().max().unwrap(),
         )
     }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp,
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, HashSet, VecDeque},
     convert::TryInto,
     fmt, io, mem,
     net::SocketAddr,
@@ -27,7 +27,7 @@ use crate::{
         EndpointEventInner, IssuedCid,
     },
     transport_parameters::{self, TransportParameters},
-    Dir, Frame, Side, StreamId, Transmit, TransportError, TransportErrorCode, VarInt,
+    Dir, Frame, ResetToken, Side, StreamId, Transmit, TransportError, TransportErrorCode, VarInt,
     LOC_CID_COUNT, MAX_STREAM_COUNT, MIN_INITIAL_SIZE, MIN_MTU, RESET_TOKEN_SIZE,
     TIMER_GRANULARITY, VERSION,
 };
@@ -75,6 +75,23 @@ where
     /// Exactly one prior to `self.rem_cids.offset` except during processing of certain
     /// NEW_CONNECTION_ID frames.
     rem_cid_seq: u64,
+    rem_cid_resettoken: Option<ResetToken>,
+
+    /// Cid rotation
+    ///
+    /// Expiration timestamp of local connection IDs
+    cids_timeline: VecDeque<CidTimeStamp>,
+    /// The lifetime of Local connection IDs
+    cids_timeout: Option<Duration>,
+    /// Number of local connection IDs that have been issued in NEW_CONNECTION_ID frames.
+    cids_issued: u64,
+    /// The sequence number of active (not yet rotated/retired by peer) local connection IDs
+    cids_active_seq: HashSet<u64>,
+    /// Sequence number so far has been acked in RETIRE_CONNECTION_ID frame
+    ack_retire_prior_to: u64,
+    /// Sequence number to set in retire_prior_to field in NEW_CONNECTION_ID frame
+    retire_cid_seq: u64,
+
     /// cid length used to decode short packet
     local_cid_len: usize,
     path: PathData,
@@ -100,8 +117,6 @@ where
     lost_packets: u64,
     events: VecDeque<Event>,
     endpoint_events: VecDeque<EndpointEventInner>,
-    /// Number of local connection IDs that have been issued in NEW_CONNECTION_ID frames.
-    cids_issued: u64,
     /// Whether the spin bit is in use for this connection
     spin_enabled: bool,
     /// Outgoing spin bit state
@@ -172,6 +187,7 @@ where
         remote: SocketAddr,
         crypto: S,
         now: Instant,
+        cids_timeout: Option<Duration>,
         local_cid_len: usize,
     ) -> Self {
         let side = if server_config.is_some() {
@@ -199,6 +215,12 @@ where
             rem_cid,
             rem_handshake_cid: rem_cid,
             rem_cid_seq: 0,
+            rem_cid_resettoken: None,
+            ack_retire_prior_to: 0,
+            retire_cid_seq: 0,
+            cids_timeline: VecDeque::new(),
+            cids_active_seq: HashSet::new(),
+            cids_timeout,
             local_cid_len,
             path: PathData::new(
                 remote,
@@ -656,10 +678,33 @@ where
                     self.handle_coalesced(now, remote, ecn, data);
                 }
             }
-            NewIdentifiers(ids) => {
-                ids.into_iter().rev().for_each(|frame| {
-                    self.spaces[SpaceId::Data].pending.new_cids.push(frame);
-                });
+            NewIdentifiers(ids, now) => {
+                let timeout = match self.cids_timeout {
+                    Some(t) => now.checked_add(t),
+                    _ => None,
+                };
+                // Record the timestamp of CID with the largest seq number
+                if let Some(last_cid) = ids.last() {
+                    if let Some(timestamp) = timeout {
+                        self.reset_cid_timer(Some(CidTimeStamp {
+                            sequence: last_cid.sequence,
+                            timestamp,
+                        }));
+                    }
+                    self.cids_issued += ids.len() as u64;
+                    ids.into_iter().rev().for_each(|frame| {
+                        self.spaces[SpaceId::Data].pending.new_cids.push(frame);
+                        self.cids_active_seq.insert(frame.sequence);
+                    });
+                } else {
+                    // Handle initial CID with active_connection_id_limit == 1
+                    if let Some(timestamp) = timeout {
+                        self.reset_cid_timer(Some(CidTimeStamp {
+                            sequence: 0,
+                            timestamp,
+                        }));
+                    }
+                }
             }
         }
     }
@@ -706,7 +751,104 @@ where
                     self.path.challenge = None;
                     self.path.challenge_pending = false;
                 }
+                Timer::PushNewCid => {
+                    let num_pushed_cids = 1;
+                    let mut ids_found = false;
+                    for id in self.ack_retire_prior_to..self.retire_cid_seq {
+                        ids_found = ids_found || self.cids_active_seq.contains(&id);
+                    }
+                    if !ids_found {
+                        self.ack_retire_prior_to = self.retire_cid_seq;
+                    }
+
+                    let next_checkpoint = self.cids_timeline.pop_front();
+                    let next_seq = next_checkpoint.unwrap().sequence + 1;
+                    let current_seq = self.retire_cid_seq;
+                    //  Endpoints SHOULD NOT issue updates of the Retire Prior To field
+                    //  before receiving RETIRE_CONNECTION_ID frames that retire all
+                    //  connection IDs indicated by the previous Retire Prior To value.
+                    // https://tools.ietf.org/html/draft-ietf-quic-transport-29#section-5.1.2
+                    if next_seq > self.retire_cid_seq && !ids_found {
+                        self.retire_cid_seq = next_seq;
+                    }
+                    // An endpoint MUST NOT
+                    // provide more connection IDs than the peer's limit.
+                    //
+                    // An endpoint MAY
+                    // send connection IDs that temporarily exceed a peer's limit if the
+                    // NEW_CONNECTION_ID frame also requires the retirement of any excess,
+                    // by including a sufficiently large value in the Retire Prior To field.
+                    // https://tools.ietf.org/html/draft-ietf-quic-transport-29#section-5.1.1
+                    // In this case, `retire prior to` must increase to accommodate new cid
+                    let must_increase_retire_cid = self.cids_active_seq.len() as u64
+                        >= self
+                            .peer_params
+                            .active_connection_id_limit
+                            .min(LOC_CID_COUNT);
+                    if must_increase_retire_cid
+                        && self.retire_cid_seq - current_seq < num_pushed_cids
+                    {
+                        self.retire_cid_seq = current_seq + num_pushed_cids;
+                    }
+
+                    // In case we already received RETIRE_CONNECTION_ID before
+                    let mut push_new_cid = false;
+                    for id in current_seq..self.retire_cid_seq {
+                        push_new_cid = push_new_cid || self.cids_active_seq.contains(&id);
+                    }
+
+                    if push_new_cid {
+                        if !self.state.is_closed() {
+                            trace!(
+                                "push a new cid to peer RETIRE_PRIOR_TO field {}",
+                                self.retire_cid_seq
+                            );
+                            self.endpoint_events
+                                .push_back(EndpointEventInner::NeedIdentifiers(
+                                    now,
+                                    num_pushed_cids,
+                                ));
+                        }
+                    } else {
+                        // We don't need to push new cid as peer has actively retired them already
+                        self.reset_cid_timer(None);
+                    }
+                }
             }
+        }
+    }
+
+    /// set timer for CID rotation
+    fn reset_cid_timer(&mut self, id: Option<CidTimeStamp>) {
+        // Remove any timestamp attached to a cid that is retired
+        while let Some(nc) = self.cids_timeline.front() {
+            if nc.sequence < self.retire_cid_seq {
+                self.cids_timeline.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        if let Some(new_cid) = id {
+            if let Some(nc) = self.cids_timeline.front_mut() {
+                if new_cid.timestamp == nc.timestamp && new_cid.sequence > nc.sequence {
+                    nc.sequence = new_cid.sequence;
+                } else {
+                    self.cids_timeline.push_back(new_cid);
+                }
+            } else {
+                self.cids_timeline.push_back(new_cid);
+            }
+        }
+
+        if let Some(next_checkpoint) = self.cids_timeline.front() {
+            trace!(
+                "set up a timer at {:?} for cid {:?}",
+                next_checkpoint.timestamp,
+                next_checkpoint.sequence
+            );
+            self.timers
+                .set(Timer::PushNewCid, next_checkpoint.timestamp);
         }
     }
 
@@ -1956,7 +2098,7 @@ where
                             }
                             self.validate_peer_params(&params)?;
                             self.set_peer_params(params);
-                            self.issue_cids();
+                            self.issue_cids(now);
                         } else {
                             // Server-only
                             self.spaces[SpaceId::Data].pending.handshake_done = true;
@@ -2003,7 +2145,7 @@ where
                             })?;
                             self.validate_peer_params(&params)?;
                             self.set_peer_params(params);
-                            self.issue_cids();
+                            self.issue_cids(now);
                             self.init_0rtt();
                         }
                         Ok(())
@@ -2283,13 +2425,24 @@ where
                             "RETIRE_CONNECTION_ID for unissued sequence number",
                         ));
                     }
+                    self.cids_active_seq.remove(&sequence);
+                    let allow_more_cid = self
+                        .peer_params
+                        .active_connection_id_limit
+                        .min(LOC_CID_COUNT)
+                        > self.cids_active_seq.len() as u64;
                     self.endpoint_events
-                        .push_back(EndpointEventInner::RetireConnectionId(sequence));
+                        .push_back(EndpointEventInner::RetireConnectionId(
+                            now,
+                            sequence,
+                            allow_more_cid,
+                        ));
                 }
                 Frame::NewConnectionId(frame) => {
                     trace!(
                         sequence = frame.sequence,
                         id = %frame.id,
+                        retire_prior_to = frame.retire_prior_to,
                     );
                     if self.rem_cid.is_empty() {
                         return Err(TransportError::PROTOCOL_VIOLATION(
@@ -2308,25 +2461,51 @@ where
                         .retire_cids
                         .extend(retired);
 
+                    let mut valid_rem_cid = Ok(());
+                    if frame.retire_prior_to > self.rem_cid_seq {
+                        // If our current CID is earlier than the first unretired one we must not
+                        // have adopted the one we just got, so it must be stored in rem_cids, so
+                        // this unwrap is guaranteed to succeed.
+                        valid_rem_cid = self.update_rem_cid();
+                    }
+
                     // Must be after retire_prior_to processing in case this CID has the highest
                     // permitted sequence number
                     use crate::cid_queue::InsertError;
-                    match self.rem_cids.insert(IssuedCid {
+                    let mut new_rem_cid = IssuedCid {
                         sequence: frame.sequence,
                         id: frame.id,
                         reset_token: frame.reset_token,
-                    }) {
-                        Ok(()) => {}
-                        Err(InsertError::ExceedsLimit) => {
-                            return Err(TransportError::CONNECTION_ID_LIMIT_ERROR(""));
-                        }
-                        Err(InsertError::Retired) => {
-                            trace!("discarding already-retired");
-                            self.spaces[SpaceId::Data]
-                                .pending
-                                .retire_cids
-                                .push(frame.sequence);
-                            continue;
+                    };
+
+                    // Guarantee the cid sequence in active rem cid (self.rem_cid) is always smallest among active ones
+                    if valid_rem_cid.is_ok() && frame.sequence + 1 == self.rem_cids.offset {
+                        let swap_cid = new_rem_cid;
+                        new_rem_cid.sequence = self.rem_cid_seq;
+                        new_rem_cid.id = self.rem_cid;
+                        new_rem_cid.reset_token = self.rem_cid_resettoken.unwrap();
+                        self.apply_new_rem_cid(swap_cid);
+                    }
+
+                    match valid_rem_cid {
+                        Ok(_) => match self.rem_cids.insert(new_rem_cid) {
+                            Ok(()) => {}
+                            Err(InsertError::ExceedsLimit) => {
+                                return Err(TransportError::CONNECTION_ID_LIMIT_ERROR(""));
+                            }
+                            Err(InsertError::Retired) => {
+                                trace!("discarding already-retired");
+                                self.spaces[SpaceId::Data]
+                                    .pending
+                                    .retire_cids
+                                    .push(frame.sequence);
+                                continue;
+                            }
+                        },
+                        Err(_) => {
+                            self.rem_cids.offset = frame.retire_prior_to + 1;
+                            // We don't have other choice but to set the current rem cid as the active one
+                            self.apply_new_rem_cid(new_rem_cid)
                         }
                     }
 
@@ -2334,11 +2513,6 @@ where
                         // We're a server using the initial remote CID for the client, so let's
                         // switch immediately to enable clientside stateless resets.
                         debug_assert_eq!(self.rem_cid_seq, 0);
-                        self.update_rem_cid().unwrap();
-                    } else if frame.retire_prior_to > self.rem_cid_seq {
-                        // If our current CID is earlier than the first unretired one we must not
-                        // have adopted the one we just got, so it must be stored in rem_cids, so
-                        // this unwrap is guaranteed to succeed.
                         self.update_rem_cid().unwrap();
                     }
                 }
@@ -2450,17 +2624,29 @@ where
 
     /// Returns Err(()) if no CIDs were available
     fn update_rem_cid(&mut self) -> Result<(), ()> {
-        let (cid, retired) = self.rem_cids.next().ok_or(())?;
-        trace!("switching to remote CID {}: {}", cid.sequence, cid.id);
-
-        // Retire the current remote CID and any CIDs we had to skip.
+        // Retire the current remote CID
         let retire_cids = &mut self.spaces[SpaceId::Data].pending.retire_cids;
         retire_cids.push(self.rem_cid_seq);
-        retire_cids.extend(retired);
 
-        // Apply the new CID
+        match self.rem_cids.next() {
+            Some(cid) => {
+                trace!("switching to remote CID {}: {}", cid.0.sequence, cid.0.id);
+
+                // Retire any CIDs we had to skip.
+                retire_cids.extend(cid.1);
+
+                // Apply new remote CID
+                self.apply_new_rem_cid(cid.0);
+                Ok(())
+            }
+            None => Err(()),
+        }
+    }
+
+    fn apply_new_rem_cid(&mut self, cid: IssuedCid) {
         self.rem_cid = cid.id;
         self.rem_cid_seq = cid.sequence;
+        self.rem_cid_resettoken = Some(cid.reset_token);
         self.endpoint_events
             .push_back(EndpointEventInner::ResetToken(
                 self.path.remote,
@@ -2470,11 +2656,10 @@ where
 
         // Reduce linkability
         self.spin = false;
-        Ok(())
     }
 
     /// Issue an initial set of connection IDs to the peer
-    fn issue_cids(&mut self) {
+    fn issue_cids(&mut self, now: Instant) {
         if self.local_cid_len == 0 {
             return;
         }
@@ -2486,8 +2671,10 @@ where
             .min(LOC_CID_COUNT)
             - 1;
         self.endpoint_events
-            .push_back(EndpointEventInner::NeedIdentifiers(n));
-        self.cids_issued += n;
+            .push_back(EndpointEventInner::NeedIdentifiers(now, n));
+        // Only add one CID we supplied while handshaking to self.cids_issued. Rest will be added when we handle NewIdentifiers event
+        self.cids_issued += 1;
+        self.cids_active_seq.insert(0);
     }
 
     fn populate_packet(&mut self, space_id: SpaceId, buf: &mut Vec<u8>) -> SentFrames {
@@ -2610,7 +2797,7 @@ where
             );
             frame::NewConnectionId {
                 sequence: issued.sequence,
-                retire_prior_to: 0,
+                retire_prior_to: self.retire_cid_seq,
                 id: issued.id,
                 reset_token: issued.reset_token,
             }
@@ -2849,12 +3036,12 @@ where
             .saturating_sub(self.in_flight.bytes)
     }
 
-    /// Whether no timers but keepalive and idle are running
+    /// Whether no timers but keepalive, idle and pushnewcid are running
     #[cfg(test)]
     pub(crate) fn is_idle(&self) -> bool {
         Timer::VALUES
             .iter()
-            .filter(|&&t| t != Timer::KeepAlive)
+            .filter(|&&t| t != Timer::KeepAlive && t != Timer::PushNewCid)
             .filter_map(|&t| Some((t, self.timers.get(t)?)))
             .min_by_key(|&(_, time)| time)
             .map_or(true, |(timer, _)| timer == Timer::Idle)
@@ -2870,6 +3057,14 @@ where
     #[cfg(test)]
     pub(crate) fn using_ecn(&self) -> bool {
         self.path.sending_ecn
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_local_cid_seq(&self) -> (u64, u64) {
+        (
+            self.cids_active_seq.iter().min().unwrap().clone(),
+            self.cids_active_seq.iter().max().unwrap().clone(),
+        )
     }
 
     fn max_ack_delay(&self) -> Duration {
@@ -3214,4 +3409,10 @@ struct PacketBuilder<'a> {
     min_size: usize,
     max_size: usize,
     span: tracing::Span,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+struct CidTimeStamp {
+    sequence: u64,
+    timestamp: Instant,
 }

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -14,23 +14,26 @@ pub(crate) enum Timer {
     PathValidation = 4,
     /// When to send a `PING` frame to keep the connection alive
     KeepAlive = 5,
+    /// When to invalidate old CID and proactively push new one via NEW_CONNECTION_ID frame
+    PushNewCid = 6,
 }
 
 impl Timer {
-    pub(crate) const VALUES: [Self; 6] = [
+    pub(crate) const VALUES: [Self; 7] = [
         Timer::LossDetection,
         Timer::Idle,
         Timer::Close,
         Timer::KeyDiscard,
         Timer::PathValidation,
         Timer::KeepAlive,
+        Timer::PushNewCid,
     ];
 }
 
 /// A table of data associated with each distinct kind of `Timer`
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct TimerTable {
-    data: [Option<Instant>; 6],
+    data: [Option<Instant>; 7],
 }
 
 impl TimerTable {

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -19,7 +19,7 @@ pub(crate) enum ConnectionEventInner {
         remaining: Option<BytesMut>,
     },
     /// New connection identifiers have been issued for the Connection
-    NewIdentifiers(Vec<IssuedCid>),
+    NewIdentifiers(Vec<IssuedCid>, Instant),
 }
 
 /// Events sent from a Connection to an Endpoint
@@ -50,9 +50,9 @@ pub(crate) enum EndpointEventInner {
     /// The reset token and/or address eligible for generating resets has been updated
     ResetToken(SocketAddr, ResetToken),
     /// The connection needs connection identifiers
-    NeedIdentifiers(u64),
+    NeedIdentifiers(Instant, u64),
     /// Stop routing connection ID for this sequence number to the connection
-    RetireConnectionId(u64),
+    RetireConnectionId(Instant, u64, bool),
 }
 
 /// Protocol-level identifier for a connection.

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1150,6 +1150,64 @@ fn keep_alive() {
 }
 
 #[test]
+fn cid_rotation() {
+    let _guard = subscribe();
+    const CID_TIMEOUT: Duration = Duration::from_secs(2);
+
+    let cid_generator_factory: fn() -> Box<dyn ConnectionIdGenerator> =
+        || Box::new(*RandomConnectionIdGenerator::new(8).set_lifetime(CID_TIMEOUT));
+
+    // Only test cid rotation on server side to have a clear output trace
+    let server = Endpoint::new(
+        Arc::new(EndpointConfig {
+            connection_id_generator_factory: Arc::new(cid_generator_factory),
+            ..EndpointConfig::default()
+        }),
+        Some(Arc::new(server_config())),
+    );
+    let client = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+
+    let mut pair = Pair::new_from_endpoint(client, server);
+    let (_, server_ch) = pair.connect();
+
+    let mut round: u64 = 1;
+    let mut stop = pair.time;
+    let end = pair.time + 5 * CID_TIMEOUT;
+
+    use crate::cid_queue::CidQueue;
+    use crate::LOC_CID_COUNT;
+    let mut active_cid_num = CidQueue::LEN as u64 + 1;
+    active_cid_num = active_cid_num.min(LOC_CID_COUNT);
+    let mut left_bound = 0;
+    let mut right_bound = active_cid_num - 1;
+
+    while pair.time < end {
+        stop += CID_TIMEOUT;
+        // Run a while until PushNewCID timer fires
+        while pair.time < stop {
+            if !pair.step() {
+                if let Some(time) = min_opt(pair.client.next_wakeup(), pair.server.next_wakeup()) {
+                    pair.time = time;
+                }
+            }
+        }
+        info!(
+            "Checking active cid sequence range before {:?} seconds",
+            round * CID_TIMEOUT.as_secs()
+        );
+        let _bound = (left_bound, right_bound);
+        assert_matches!(
+            pair.server_conn_mut(server_ch).active_local_cid_seq(),
+            _bound
+        );
+        round += 1;
+        left_bound += active_cid_num;
+        right_bound += active_cid_num;
+        pair.drive_server();
+    }
+}
+
+#[test]
 fn finish_stream_flow_control_reordered() {
     let _guard = subscribe();
     let mut pair = Pair::default();

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -51,6 +51,25 @@ impl Pair {
         }
     }
 
+    pub fn new_from_endpoint(client: Endpoint, server: Endpoint) -> Self {
+        let server_addr = SocketAddr::new(
+            Ipv6Addr::LOCALHOST.into(),
+            SERVER_PORTS.lock().unwrap().next().unwrap(),
+        );
+        let client_addr = SocketAddr::new(
+            Ipv6Addr::LOCALHOST.into(),
+            CLIENT_PORTS.lock().unwrap().next().unwrap(),
+        );
+        Self {
+            server: TestEndpoint::new(server, server_addr),
+            client: TestEndpoint::new(client, client_addr),
+            time: Instant::now(),
+            latency: Duration::new(0, 0),
+            spins: 0,
+            last_spin: false,
+        }
+    }
+
     /// Returns whether the connection is not idle
     pub fn step(&mut self) -> bool {
         self.drive_client();

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -153,9 +153,11 @@ mod test {
         rand::thread_rng().fill_bytes(&mut key);
         let key = <hmac::Key as HmacKey>::new(&key).unwrap();
         let addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 4433);
-        let retry_src_cid = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
+        let (retry_src_cid, _) = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
         let token = RetryToken {
-            orig_dst_cid: RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid(),
+            orig_dst_cid: RandomConnectionIdGenerator::new(MAX_CID_SIZE)
+                .generate_cid()
+                .0,
             issued: UNIX_EPOCH + Duration::new(42, 0), // Fractional seconds would be lost
         };
         let encoded = token.encode(&key, &addr, &retry_src_cid);


### PR DESCRIPTION
This is a follow-up PR after https://github.com/djc/quinn/pull/851

**Objective**: Implement CID rotation. Peer now can proactively retire previously issued CIDs after a fixed amount of duration, in order to prevent "CID exhaustion" attack.

**Approach**:

1. Modify `NeedIdentifiers` event handling logic to setup a timer in the future when CID needs to be retired.
2. Add a `PushNewCID` timer and corresponding logic that eventually issues `NEW_CONNECTION_ID` frame when timer expires.
3. Improve `RETIRE_CONNECTION_ID` processing logic. Add a hash set to track the active cid sequence used by the current connection.
4. Fix a hidden bug when processing `NEW_CONNECTION_ID` frame where `retire_prior_to` may retire all CIDs in both `cid_queue` and `rem_cid`, and cause a corrupted `offset` value.
